### PR TITLE
Added Option to select Cognitive Service Kind & Disable Azure Search

### DIFF
--- a/.github/linters/.arm-ttk.psd1
+++ b/.github/linters/.arm-ttk.psd1
@@ -8,6 +8,7 @@
         'DeploymentTemplate Must Not Contain Hardcoded Uri'
         'DependsOn Best Practices',
         'Outputs Must Not Contain Secrets',
-        'IDs Should Be Derived From ResourceIDs'
+        'IDs Should Be Derived From ResourceIDs',
+        'Parameters Must Be Referenced'
     )
 }

--- a/.github/linters/.arm-ttk.psd1
+++ b/.github/linters/.arm-ttk.psd1
@@ -4,11 +4,11 @@
 @{
     # Test = @( )
     Skip = @(
-        'Template Should Not Contain Blanks',
+        'Template Should Not Contain Blanks'
         'DeploymentTemplate Must Not Contain Hardcoded Uri'
-        'DependsOn Best Practices',
-        'Outputs Must Not Contain Secrets',
-        'IDs Should Be Derived From ResourceIDs',
+        'DependsOn Best Practices'
+        'Outputs Must Not Contain Secrets'
+        'IDs Should Be Derived From ResourceIDs'
         'Parameters Must Be Referenced'
     )
 }

--- a/.github/linters/.powershell-psscriptanalyzer.psd1
+++ b/.github/linters/.powershell-psscriptanalyzer.psd1
@@ -8,7 +8,7 @@
     #)
     #IncludeDefaultRules=${true}
     ExcludeRules = @(
-       'PSUseShouldProcessForStateChangingFunctions',
+       'PSUseShouldProcessForStateChangingFunctions'
        'PSReviewUnusedParameter'
        'PSAvoidGlobalVars'
        'PSAvoidUsingPlainTextForPassword'

--- a/docs/EnterpriseScaleAnalytics-AzureDevOpsDeployment.md
+++ b/docs/EnterpriseScaleAnalytics-AzureDevOpsDeployment.md
@@ -88,6 +88,8 @@ To begin, please open the [infra/params.dev.json](/infra/params.dev.json). In th
 | databricksWorkspaceUrl | Specifies the workspace URL of the Databricks workspace that will be connected to the Machine Learning Workspace. | `adb-{databricks-workspace-id}.azuredatabricks.net` |
 | databricksAccessToken | Specifies the access token of the Databricks workspace that will be connected to the Machine Learning Workspace. Use a secret for this parameter and overwrite as part of the deployment pipelines. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Purview/accounts/{purview-name}` |
 | enableRoleAssignments | Specifies whether role assignments should be enabled. | `true` or `false` |
+| cognitiveServiceKinds | Specifies the cognitive service kind that will be deployed. | [`FormRecognizer`, `LUIS`] |
+| enableSearch | Specifies whether Azure Search should be deployed as part of the template. | `true` or `false` |
 | subnetId | Specifies the resource ID of the subnet to which all services will connect. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Network/virtualNetworks/{vnet-name}/subnets/{subnet-name}` |
 | privateDnsZoneIdKeyVault | Specifies the resource ID of the private DNS zone for KeyVault. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Network/privateDnsZones/privatelink.vaultcore.azure.net` |
 | privateDnsZoneIdSynapseDev | Specifies the resource ID of the private DNS zone for Synapse Dev. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Network/privateDnsZones/privatelink.dev.azuresynapse.net` |

--- a/docs/EnterpriseScaleAnalytics-GitHubActionsDeployment.md
+++ b/docs/EnterpriseScaleAnalytics-GitHubActionsDeployment.md
@@ -79,6 +79,8 @@ To begin, please open the [infra/params.dev.json](/infra/params.dev.json). In th
 | databricksWorkspaceUrl | Specifies the workspace URL of the Databricks workspace that will be connected to the Machine Learning Workspace. | `adb-{databricks-workspace-id}.azuredatabricks.net` |
 | databricksAccessToken | Specifies the access token of the Databricks workspace that will be connected to the Machine Learning Workspace. Use a secret for this parameter and overwrite as part of the deployment pipelines. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Purview/accounts/{purview-name}` |
 | enableRoleAssignments | Specifies whether role assignments should be enabled. | `true` or `false` |
+| cognitiveServiceKinds | Specifies the cognitive service kind that will be deployed. | [`FormRecognizer`, `LUIS`] |
+| enableSearch | Specifies whether Azure Search should be deployed as part of the template. | `true` or `false` |
 | subnetId | Specifies the resource ID of the subnet to which all services will connect. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Network/virtualNetworks/{vnet-name}/subnets/{subnet-name}` |
 | privateDnsZoneIdKeyVault | Specifies the resource ID of the private DNS zone for KeyVault. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Network/privateDnsZones/privatelink.vaultcore.azure.net` |
 | privateDnsZoneIdSynapseDev | Specifies the resource ID of the private DNS zone for Synapse Dev. | `/subscriptions/{subscription-id}/resourceGroups/{rg-name}/providers/Microsoft.Network/privateDnsZones/privatelink.dev.azuresynapse.net` |

--- a/docs/reference/portal.dataProduct.json
+++ b/docs/reference/portal.dataProduct.json
@@ -863,6 +863,94 @@
                                     }
                                 },
                                 {
+                                    "name": "cognitiveServiceKind",
+                                    "label": "Cognitive Services Kind",
+                                    "type": "Microsoft.Common.DropDown",
+                                    "visible": true,
+                                    "defaultValue": "None",
+                                    "toolTip": "Select the kind of Cognitive Service that should be deployed.",
+                                    "multiselect": false,
+                                    "selectAll": false,
+                                    "filter": true,
+                                    "filterPlaceholder": "Filter items ...",
+                                    "multiLine": true,
+                                    "constraints": {
+                                        "allowedValues": [
+                                            {
+                                                "label": "None",
+                                                "description": "Select if you do NOT want to deploy a Cognitive Service.",
+                                                "value": "None"
+                                            },
+                                            {
+                                                "label": "Anomaly Detector",
+                                                "description": "Select if you want to deploy Anomaly Detector.",
+                                                "value": "AnomalyDetector"
+                                            },
+                                            {
+                                                "label": "Computer Vision",
+                                                "description": "Select if you want to deploy Computer Vision.",
+                                                "value": "ComputerVision"
+                                            },
+                                            {
+                                                "label": "Content Moderator",
+                                                "description": "Select if you want to deploy Content Moderator.",
+                                                "value": "ContentModerator"
+                                            },
+                                            {
+                                                "label": "Custom Vision",
+                                                "description": "Select if you want to deploy Custom Vision.",
+                                                "value": "CustomVision.Training"
+                                            },
+                                            {
+                                                "label": "Face",
+                                                "description": "Select if you want to deploy Face.",
+                                                "value": "Face"
+                                            },
+                                            {
+                                                "label": "Form Recognizer",
+                                                "description": "Select if you want to deploy Form Recognizer.",
+                                                "value": "FormRecognizer"
+                                            },
+                                            {
+                                                "label": "Immersive Reader",
+                                                "description": "Select if you want to deploy Immersive Reader.",
+                                                "value": "ImmersiveReader"
+                                            },
+                                            {
+                                                "label": "LUIS",
+                                                "description": "Select if you want to deploy Language Understanding Intelligent Service.",
+                                                "value": "LUIS"
+                                            },
+                                            {
+                                                "label": "Personalizer",
+                                                "description": "Select if you want to deploy Personalizer.",
+                                                "value": "Personalizer"
+                                            },
+                                            {
+                                                "label": "Speech Services",
+                                                "description": "Select if you want to deploy Speech Services.",
+                                                "value": "SpeechServices"
+                                            },
+                                            {
+                                                "label": "Text Analytics",
+                                                "description": "Select if you want to deploy Text Analytics.",
+                                                "value": "TextAnalytics"
+                                            },
+                                            {
+                                                "label": "QnA Maker",
+                                                "description": "Select if you want to deploy QnA Maker.",
+                                                "value": "QnAMaker"
+                                            },
+                                            {
+                                                "label": "Translator Text",
+                                                "description": "Select if you want to deploy Translator Text.",
+                                                "value": "TranslatorText"
+                                            }
+                                        ],
+                                        "required": true
+                                    }
+                                },
+                                {
                                     "name": "infoBoxRoleAssignment",
                                     "type": "Microsoft.Common.InfoBox",
                                     "visible": true,
@@ -1309,6 +1397,7 @@
                 "databricksWorkspaceUrl": "[if(empty(steps('generalSettings').machineLearningDeploymentSettings.databricksWorkspaceUrl.properties.workspaceUrl), '', steps('generalSettings').machineLearningDeploymentSettings.databricksWorkspaceUrl.properties.workspaceUrl)]",
                 "databricksAccessToken": "[if(empty(steps('generalSettings').machineLearningDeploymentSettings.databricksAccessToken), '', steps('generalSettings').machineLearningDeploymentSettings.databricksAccessToken)]",
                 "enableRoleAssignments": "[steps('generalSettings').generalSettings.enableRoleAssignments]",
+                "cognitiveServiceKind": "[if(empty(steps('generalSettings').generalSettings.cognitiveServiceKind), '', steps('generalSettings').generalSettings.cognitiveServiceKind)]",
                 "subnetId": "[if(empty(steps('connectivitySettings').virtualNetwork.subnetId), '', steps('connectivitySettings').virtualNetwork.subnetId)]",
                 "privateDnsZoneIdKeyVault": "[if(empty(steps('connectivitySettings').privateDnsZones.privateDnsZoneIdKeyVault), '', steps('connectivitySettings').privateDnsZones.privateDnsZoneIdKeyVault)]",
                 "privateDnsZoneIdSynapseDev": "[if(empty(steps('connectivitySettings').privateDnsZones.privateDnsZoneIdSynapseDev), '', steps('connectivitySettings').privateDnsZones.privateDnsZoneIdSynapseDev)]",

--- a/docs/reference/portal.dataProduct.json
+++ b/docs/reference/portal.dataProduct.json
@@ -932,11 +932,6 @@
                                                 "value": "TextAnalytics"
                                             },
                                             {
-                                                "label": "QnA Maker",
-                                                "description": "Select if you want to deploy QnA Maker.",
-                                                "value": "QnAMaker"
-                                            },
-                                            {
                                                 "label": "Translator Text",
                                                 "description": "Select if you want to deploy Translator Text.",
                                                 "value": "TranslatorText"

--- a/docs/reference/portal.dataProduct.json
+++ b/docs/reference/portal.dataProduct.json
@@ -932,9 +932,9 @@
                                                 "value": "TextAnalytics"
                                             },
                                             {
-                                                "label": "Translator Text",
-                                                "description": "Select if you want to deploy Translator Text.",
-                                                "value": "TranslatorText"
+                                                "label": "Text Translator",
+                                                "description": "Select if you want to deploy Text Translator.",
+                                                "value": "TextTranslation"
                                             }
                                         ],
                                         "required": false

--- a/docs/reference/portal.dataProduct.json
+++ b/docs/reference/portal.dataProduct.json
@@ -863,24 +863,19 @@
                                     }
                                 },
                                 {
-                                    "name": "cognitiveServiceKind",
+                                    "name": "cognitiveServiceKinds",
                                     "label": "Cognitive Services Kind",
                                     "type": "Microsoft.Common.DropDown",
                                     "visible": true,
                                     "defaultValue": "None",
                                     "toolTip": "Select the kind of Cognitive Service that should be deployed.",
-                                    "multiselect": false,
+                                    "multiselect": true,
                                     "selectAll": false,
                                     "filter": true,
                                     "filterPlaceholder": "Filter items ...",
                                     "multiLine": true,
                                     "constraints": {
                                         "allowedValues": [
-                                            {
-                                                "label": "None",
-                                                "description": "Select if you do NOT want to deploy a Cognitive Service.",
-                                                "value": "None"
-                                            },
                                             {
                                                 "label": "Anomaly Detector",
                                                 "description": "Select if you want to deploy Anomaly Detector.",
@@ -947,7 +942,19 @@
                                                 "value": "TranslatorText"
                                             }
                                         ],
-                                        "required": true
+                                        "required": false
+                                    }
+                                },
+                                {
+                                    "name": "enableSearch",
+                                    "label": "Enable Azure Search",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "visible": true,
+                                    "defaultValue": false,
+                                    "toolTip": "Enable the deployment of Azure Search.",
+                                    "constraints": {
+                                        "required": false,
+                                        "validationMessage": "Enable the deployment of Azure Search."
                                     }
                                 },
                                 {
@@ -1397,7 +1404,8 @@
                 "databricksWorkspaceUrl": "[if(empty(steps('generalSettings').machineLearningDeploymentSettings.databricksWorkspaceUrl.properties.workspaceUrl), '', steps('generalSettings').machineLearningDeploymentSettings.databricksWorkspaceUrl.properties.workspaceUrl)]",
                 "databricksAccessToken": "[if(empty(steps('generalSettings').machineLearningDeploymentSettings.databricksAccessToken), '', steps('generalSettings').machineLearningDeploymentSettings.databricksAccessToken)]",
                 "enableRoleAssignments": "[steps('generalSettings').generalSettings.enableRoleAssignments]",
-                "cognitiveServiceKind": "[if(empty(steps('generalSettings').generalSettings.cognitiveServiceKind), '', steps('generalSettings').generalSettings.cognitiveServiceKind)]",
+                "cognitiveServiceKinds": "[if(empty(steps('generalSettings').generalSettings.cognitiveServiceKinds), parse('[]'), steps('generalSettings').generalSettings.cognitiveServiceKinds)]",
+                "enableSearch": "[steps('generalSettings').generalSettings.enableSearch]",
                 "subnetId": "[if(empty(steps('connectivitySettings').virtualNetwork.subnetId), '', steps('connectivitySettings').virtualNetwork.subnetId)]",
                 "privateDnsZoneIdKeyVault": "[if(empty(steps('connectivitySettings').privateDnsZones.privateDnsZoneIdKeyVault), '', steps('connectivitySettings').privateDnsZones.privateDnsZoneIdKeyVault)]",
                 "privateDnsZoneIdSynapseDev": "[if(empty(steps('connectivitySettings').privateDnsZones.privateDnsZoneIdSynapseDev), '', steps('connectivitySettings').privateDnsZones.privateDnsZoneIdSynapseDev)]",

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -67,7 +67,6 @@ param enableRoleAssignments bool = false
   'Personalizer'
   'SpeechServices'
   'TextAnalytics'
-  'QnAMaker'
   'TranslatorText'
 ])
 @description('Specifies the cognitive service kind that will be deployed.')

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -67,7 +67,7 @@ param enableRoleAssignments bool = false
   'Personalizer'
   'SpeechServices'
   'TextAnalytics'
-  'TranslatorText'
+  'TextTranslation'
 ])
 @description('Specifies the cognitive service kind that will be deployed.')
 param cognitiveServiceKinds array = []

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -54,6 +54,25 @@ param databricksWorkspaceUrl string = ''
 param databricksAccessToken string = ''
 @description('Specifies whether role assignments should be enabled for Synapse (Blob Storage Contributor to default storage account).')
 param enableRoleAssignments bool = false
+@allowed([
+  'None'
+  'AnomalyDetector'
+  'ComputerVision'
+  'ContentModerator'
+  'CustomVision.Training'
+  'CustomVision.Prediction'
+  'Face'
+  'FormRecognizer'
+  'ImmersiveReader'
+  'LUIS'
+  'Personalizer'
+  'SpeechServices'
+  'TextAnalytics'
+  'QnAMaker'
+  'TranslatorText'
+])
+@description('Specifies the cognitive service kind that will be deployed.')
+param cognitiveServiceKind string = 'None'
 
 // Network parameters
 @description('Specifies the resource ID of the subnet to which all services will connect.')
@@ -172,7 +191,7 @@ module datafactory001 'modules/services/datafactory.bicep' = if (processingServi
   }
 }
 
-module cognitiveservice001 'modules/services/cognitiveservices.bicep' = {
+module cognitiveservice001 'modules/services/cognitiveservices.bicep' = if(cognitiveServiceKind != 'None') {
   name: 'cognitiveservice001'
   scope: resourceGroup()
   params: {
@@ -180,7 +199,7 @@ module cognitiveservice001 'modules/services/cognitiveservices.bicep' = {
     tags: tagsJoined
     subnetId: subnetId
     cognitiveServiceName: cognitiveservice001Name
-    cognitiveServiceKind: 'FormRecognizer'
+    cognitiveServiceKind: cognitiveServiceKind
     cognitiveServiceSkuName: 'S0'
     privateDnsZoneIdCognitiveService: privateDnsZoneIdCognitiveService
   }

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -55,7 +55,6 @@ param databricksAccessToken string = ''
 @description('Specifies whether role assignments should be enabled for Synapse (Blob Storage Contributor to default storage account).')
 param enableRoleAssignments bool = false
 @allowed([
-  'None'
   'AnomalyDetector'
   'ComputerVision'
   'ContentModerator'
@@ -72,7 +71,9 @@ param enableRoleAssignments bool = false
   'TranslatorText'
 ])
 @description('Specifies the cognitive service kind that will be deployed.')
-param cognitiveServiceKind string = 'None'
+param cognitiveServiceKinds array = []
+@description('Specifies whether Azure Search should be deployed as part of the template.')
+param enableSearch bool = false
 
 // Network parameters
 @description('Specifies the resource ID of the subnet to which all services will connect.')
@@ -126,7 +127,7 @@ var datalakeFileSystemScopes = [for datalakeFileSystemId in datalakeFileSystemId
 var keyvault001Name = '${name}-vault001'
 var synapse001Name = '${name}-synapse001'
 var datafactory001Name = '${name}-datafactory001'
-var cognitiveservice001Name = '${name}-cognitiveservice001'
+var cognitiveservicesName = '${name}-cognitiveservice'
 var search001Name = '${name}-search001'
 var applicationInsights001Name = '${name}-insights001'
 var containerRegistry001Name = '${name}-containerregistry001'
@@ -191,21 +192,21 @@ module datafactory001 'modules/services/datafactory.bicep' = if (processingServi
   }
 }
 
-module cognitiveservice001 'modules/services/cognitiveservices.bicep' = if(cognitiveServiceKind != 'None') {
-  name: 'cognitiveservice001'
+module cognitiveservices 'modules/services/cognitiveservices.bicep' = [for (cognitiveServiceKind, index) in cognitiveServiceKinds: {
+  name: 'cognitiveservice${padLeft(index + 1, 3, '0')}'
   scope: resourceGroup()
   params: {
     location: location
     tags: tagsJoined
     subnetId: subnetId
-    cognitiveServiceName: cognitiveservice001Name
+    cognitiveServiceName: '${cognitiveservicesName}${padLeft(index + 1, 3, '0')}'
     cognitiveServiceKind: cognitiveServiceKind
     cognitiveServiceSkuName: 'S0'
     privateDnsZoneIdCognitiveService: privateDnsZoneIdCognitiveService
   }
-}
+}]
 
-module search001 'modules/services/search.bicep' = {
+module search001 'modules/services/search.bicep' = if(enableSearch) {
   name: 'search001'
   scope: resourceGroup()
   params: {

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.613.9944",
-      "templateHash": "3396878266160804377"
+      "templateHash": "14166027831562377715"
     }
   },
   "parameters": {
@@ -1255,7 +1255,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.613.9944",
-              "templateHash": "17936362145104556669"
+              "templateHash": "1072312818828579259"
             }
           },
           "parameters": {
@@ -1314,7 +1314,7 @@
                 "type": "SystemAssigned"
               },
               "sku": {
-                "name": "[parameters('cognitiveServiceSkuName')]"
+                "name": "[if(equals(parameters('cognitiveServiceKind'), 'ComputerVision'), 'S1', if(equals(parameters('cognitiveServiceKind'), 'TextAnalytics'), 'S', parameters('cognitiveServiceSkuName')))]"
               },
               "kind": "[parameters('cognitiveServiceKind')]",
               "properties": {

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.613.9944",
-      "templateHash": "7407140336089323096"
+      "templateHash": "809461554380075757"
     }
   },
   "parameters": {
@@ -137,14 +137,13 @@
         "description": "Specifies whether role assignments should be enabled for Synapse (Blob Storage Contributor to default storage account)."
       }
     },
-    "cognitiveServiceKind": {
-      "type": "string",
-      "defaultValue": "None",
+    "cognitiveServiceKinds": {
+      "type": "array",
+      "defaultValue": [],
       "metadata": {
         "description": "Specifies the cognitive service kind that will be deployed."
       },
       "allowedValues": [
-        "None",
         "AnomalyDetector",
         "ComputerVision",
         "ContentModerator",
@@ -160,6 +159,13 @@
         "QnAMaker",
         "TranslatorText"
       ]
+    },
+    "enableSearch": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Specifies whether Azure Search should be deployed as part of the template."
+      }
     },
     "subnetId": {
       "type": "string",
@@ -281,7 +287,7 @@
     "keyvault001Name": "[format('{0}-vault001', variables('name'))]",
     "synapse001Name": "[format('{0}-synapse001', variables('name'))]",
     "datafactory001Name": "[format('{0}-datafactory001', variables('name'))]",
-    "cognitiveservice001Name": "[format('{0}-cognitiveservice001', variables('name'))]",
+    "cognitiveservicesName": "[format('{0}-cognitiveservice', variables('name'))]",
     "search001Name": "[format('{0}-search001', variables('name'))]",
     "applicationInsights001Name": "[format('{0}-insights001', variables('name'))]",
     "containerRegistry001Name": "[format('{0}-containerregistry001', variables('name'))]",
@@ -1208,10 +1214,13 @@
       ]
     },
     {
-      "condition": "[not(equals(parameters('cognitiveServiceKind'), 'None'))]",
+      "copy": {
+        "name": "cognitiveservices",
+        "count": "[length(parameters('cognitiveServiceKinds'))]"
+      },
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2019-10-01",
-      "name": "cognitiveservice001",
+      "name": "[format('cognitiveservice{0}', padLeft(add(copyIndex(), 1), 3, '0'))]",
       "properties": {
         "expressionEvaluationOptions": {
           "scope": "inner"
@@ -1228,10 +1237,10 @@
             "value": "[parameters('subnetId')]"
           },
           "cognitiveServiceName": {
-            "value": "[variables('cognitiveservice001Name')]"
+            "value": "[format('{0}{1}', variables('cognitiveservicesName'), padLeft(add(copyIndex(), 1), 3, '0'))]"
           },
           "cognitiveServiceKind": {
-            "value": "[parameters('cognitiveServiceKind')]"
+            "value": "[parameters('cognitiveServiceKinds')[copyIndex()]]"
           },
           "cognitiveServiceSkuName": {
             "value": "S0"
@@ -1247,7 +1256,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.613.9944",
-              "templateHash": "7867837400623953116"
+              "templateHash": "1987002146294078897"
             }
           },
           "parameters": {
@@ -1270,7 +1279,6 @@
             "cognitiveServiceKind": {
               "type": "string",
               "allowedValues": [
-                "None",
                 "AnomalyDetector",
                 "ComputerVision",
                 "CognitiveServices",
@@ -1299,7 +1307,6 @@
           },
           "resources": [
             {
-              "condition": "[not(equals(parameters('cognitiveServiceKind'), 'None'))]",
               "type": "Microsoft.CognitiveServices/accounts",
               "apiVersion": "2021-04-30",
               "name": "[parameters('cognitiveServiceName')]",
@@ -1381,6 +1388,7 @@
       }
     },
     {
+      "condition": "[parameters('enableSearch')]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2019-10-01",
       "name": "search001",

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.613.9944",
-      "templateHash": "7118739398889617477"
+      "templateHash": "4455117515810704882"
     }
   },
   "parameters": {
@@ -136,6 +136,30 @@
       "metadata": {
         "description": "Specifies whether role assignments should be enabled for Synapse (Blob Storage Contributor to default storage account)."
       }
+    },
+    "cognitiveServiceKind": {
+      "type": "string",
+      "defaultValue": "None",
+      "metadata": {
+        "description": "Specifies the cognitive service kind that will be deployed."
+      },
+      "allowedValues": [
+        "None",
+        "AnomalyDetector",
+        "ComputerVision",
+        "ContentModerator",
+        "CustomVision.Training",
+        "CustomVision.Prediction",
+        "Face",
+        "FormRecognizer",
+        "ImmersiveReader",
+        "LUIS",
+        "Personalizer",
+        "SpeechServices",
+        "TextAnalytics",
+        "QnAMaker",
+        "TranslatorText"
+      ]
     },
     "subnetId": {
       "type": "string",
@@ -1184,6 +1208,7 @@
       ]
     },
     {
+      "condition": "[not(equals(parameters('cognitiveServiceKind'), 'None'))]",
       "type": "Microsoft.Resources/deployments",
       "apiVersion": "2019-10-01",
       "name": "cognitiveservice001",
@@ -1206,7 +1231,7 @@
             "value": "[variables('cognitiveservice001Name')]"
           },
           "cognitiveServiceKind": {
-            "value": "FormRecognizer"
+            "value": "[parameters('cognitiveServiceKind')]"
           },
           "cognitiveServiceSkuName": {
             "value": "S0"
@@ -1222,7 +1247,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.613.9944",
-              "templateHash": "1987002146294078897"
+              "templateHash": "418571688287107858"
             }
           },
           "parameters": {
@@ -1245,6 +1270,7 @@
             "cognitiveServiceKind": {
               "type": "string",
               "allowedValues": [
+                "None",
                 "AnomalyDetector",
                 "ComputerVision",
                 "CognitiveServices",

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.613.9944",
-      "templateHash": "4455117515810704882"
+      "templateHash": "8258172417069678188"
     }
   },
   "parameters": {
@@ -1247,7 +1247,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.613.9944",
-              "templateHash": "418571688287107858"
+              "templateHash": "7867837400623953116"
             }
           },
           "parameters": {
@@ -1299,6 +1299,7 @@
           },
           "resources": [
             {
+              "condition": "[not(equals(parameters('cognitiveServiceKind'), 'None'))]",
               "type": "Microsoft.CognitiveServices/accounts",
               "apiVersion": "2021-04-30",
               "name": "[parameters('cognitiveServiceName')]",

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.613.9944",
-      "templateHash": "8258172417069678188"
+      "templateHash": "7407140336089323096"
     }
   },
   "parameters": {
@@ -1592,7 +1592,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.613.9944",
-              "templateHash": "7730118055684773448"
+              "templateHash": "11163868011668257849"
             }
           },
           "parameters": {
@@ -1613,7 +1613,7 @@
           "resources": [
             {
               "type": "Microsoft.Insights/components",
-              "apiVersion": "2020-02-02-preview",
+              "apiVersion": "2020-02-02",
               "name": "[parameters('applicationInsightsName')]",
               "location": "[parameters('location')]",
               "tags": "[parameters('tags')]",

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.613.9944",
-      "templateHash": "14166027831562377715"
+      "templateHash": "17088196166842914464"
     }
   },
   "parameters": {
@@ -156,7 +156,7 @@
         "Personalizer",
         "SpeechServices",
         "TextAnalytics",
-        "TranslatorText"
+        "TextTranslation"
       ]
     },
     "enableSearch": {
@@ -1255,7 +1255,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.613.9944",
-              "templateHash": "1072312818828579259"
+              "templateHash": "3093428550225992785"
             }
           },
           "parameters": {
@@ -1291,7 +1291,7 @@
                 "Personalizer",
                 "SpeechServices",
                 "TextAnalytics",
-                "TranslatorText"
+                "TextTranslation"
               ]
             },
             "privateDnsZoneIdCognitiveService": {
@@ -1314,7 +1314,7 @@
                 "type": "SystemAssigned"
               },
               "sku": {
-                "name": "[if(equals(parameters('cognitiveServiceKind'), 'ComputerVision'), 'S1', if(equals(parameters('cognitiveServiceKind'), 'TextAnalytics'), 'S', parameters('cognitiveServiceSkuName')))]"
+                "name": "[if(or(equals(parameters('cognitiveServiceKind'), 'ComputerVision'), equals(parameters('cognitiveServiceKind'), 'TextTranslation')), 'S1', if(equals(parameters('cognitiveServiceKind'), 'TextAnalytics'), 'S', parameters('cognitiveServiceSkuName')))]"
               },
               "kind": "[parameters('cognitiveServiceKind')]",
               "properties": {

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.613.9944",
-      "templateHash": "809461554380075757"
+      "templateHash": "15714938356539976719"
     }
   },
   "parameters": {
@@ -1256,7 +1256,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.613.9944",
-              "templateHash": "1987002146294078897"
+              "templateHash": "9178720080180332876"
             }
           },
           "parameters": {
@@ -1324,9 +1324,6 @@
                 "apiProperties": {},
                 "customSubDomainName": "[parameters('cognitiveServiceName')]",
                 "disableLocalAuth": true,
-                "encryption": {
-                  "keySource": "Microsoft.CognitiveServices"
-                },
                 "networkAcls": {
                   "defaultAction": "Deny",
                   "ipRules": [],

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.613.9944",
-      "templateHash": "15714938356539976719"
+      "templateHash": "3396878266160804377"
     }
   },
   "parameters": {
@@ -156,7 +156,6 @@
         "Personalizer",
         "SpeechServices",
         "TextAnalytics",
-        "QnAMaker",
         "TranslatorText"
       ]
     },
@@ -1256,7 +1255,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.613.9944",
-              "templateHash": "9178720080180332876"
+              "templateHash": "17936362145104556669"
             }
           },
           "parameters": {
@@ -1292,7 +1291,6 @@
                 "Personalizer",
                 "SpeechServices",
                 "TextAnalytics",
-                "QnAMaker",
                 "TranslatorText"
               ]
             },

--- a/infra/modules/services/applicationinsights.bicep
+++ b/infra/modules/services/applicationinsights.bicep
@@ -13,7 +13,7 @@ param logAnalyticsWorkspaceId string
 // Variables
 
 // Resources
-resource applicationInsights 'Microsoft.Insights/components@2020-02-02-preview' = {
+resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
   name: applicationInsightsName
   location: location
   tags: tags

--- a/infra/modules/services/cognitiveservices.bicep
+++ b/infra/modules/services/cognitiveservices.bicep
@@ -11,6 +11,7 @@ param subnetId string
 param cognitiveServiceName string
 param cognitiveServiceSkuName string = 'S0'
 @allowed([
+  'None'
   'AnomalyDetector'
   'ComputerVision'
   'CognitiveServices'

--- a/infra/modules/services/cognitiveservices.bicep
+++ b/infra/modules/services/cognitiveservices.bicep
@@ -41,7 +41,7 @@ resource cognitiveService 'Microsoft.CognitiveServices/accounts@2021-04-30' = {
     type: 'SystemAssigned'
   }
   sku: {
-    name: cognitiveServiceSkuName
+    name: cognitiveServiceKind == 'ComputerVision' ? 'S1' : cognitiveServiceKind == 'TextAnalytics' ? 'S' : cognitiveServiceSkuName
   }
   kind: cognitiveServiceKind
   properties: {

--- a/infra/modules/services/cognitiveservices.bicep
+++ b/infra/modules/services/cognitiveservices.bicep
@@ -24,7 +24,7 @@ param cognitiveServiceSkuName string = 'S0'
   'Personalizer'
   'SpeechServices'
   'TextAnalytics'
-  'TranslatorText'
+  'TextTranslation'
 ])
 param cognitiveServiceKind string
 param privateDnsZoneIdCognitiveService string = ''
@@ -41,7 +41,7 @@ resource cognitiveService 'Microsoft.CognitiveServices/accounts@2021-04-30' = {
     type: 'SystemAssigned'
   }
   sku: {
-    name: cognitiveServiceKind == 'ComputerVision' ? 'S1' : cognitiveServiceKind == 'TextAnalytics' ? 'S' : cognitiveServiceSkuName
+    name: cognitiveServiceKind == 'ComputerVision' || cognitiveServiceKind == 'TextTranslation' ? 'S1' : cognitiveServiceKind == 'TextAnalytics' ? 'S' : cognitiveServiceSkuName
   }
   kind: cognitiveServiceKind
   properties: {

--- a/infra/modules/services/cognitiveservices.bicep
+++ b/infra/modules/services/cognitiveservices.bicep
@@ -35,7 +35,7 @@ param privateDnsZoneIdCognitiveService string = ''
 var cognitiveServicePrivateEndpointName = '${cognitiveService.name}-private-endpoint'
 
 // Resources
-resource cognitiveService 'Microsoft.CognitiveServices/accounts@2021-04-30' = {
+resource cognitiveService 'Microsoft.CognitiveServices/accounts@2021-04-30' = if(cognitiveServiceKind != 'None') {
   name: cognitiveServiceName
   location: location
   tags: tags

--- a/infra/modules/services/cognitiveservices.bicep
+++ b/infra/modules/services/cognitiveservices.bicep
@@ -50,9 +50,6 @@ resource cognitiveService 'Microsoft.CognitiveServices/accounts@2021-04-30' = {
     apiProperties: {}
     customSubDomainName: cognitiveServiceName
     disableLocalAuth: true
-    encryption: {
-      keySource: 'Microsoft.CognitiveServices'
-    }
     networkAcls: {
       defaultAction: 'Deny'
       ipRules: []

--- a/infra/modules/services/cognitiveservices.bicep
+++ b/infra/modules/services/cognitiveservices.bicep
@@ -24,7 +24,6 @@ param cognitiveServiceSkuName string = 'S0'
   'Personalizer'
   'SpeechServices'
   'TextAnalytics'
-  'QnAMaker'
   'TranslatorText'
 ])
 param cognitiveServiceKind string

--- a/infra/modules/services/cognitiveservices.bicep
+++ b/infra/modules/services/cognitiveservices.bicep
@@ -11,7 +11,6 @@ param subnetId string
 param cognitiveServiceName string
 param cognitiveServiceSkuName string = 'S0'
 @allowed([
-  'None'
   'AnomalyDetector'
   'ComputerVision'
   'CognitiveServices'
@@ -35,7 +34,7 @@ param privateDnsZoneIdCognitiveService string = ''
 var cognitiveServicePrivateEndpointName = '${cognitiveService.name}-private-endpoint'
 
 // Resources
-resource cognitiveService 'Microsoft.CognitiveServices/accounts@2021-04-30' = if(cognitiveServiceKind != 'None') {
+resource cognitiveService 'Microsoft.CognitiveServices/accounts@2021-04-30' = {
   name: cognitiveServiceName
   location: location
   tags: tags

--- a/infra/params.dev.json
+++ b/infra/params.dev.json
@@ -53,6 +53,9 @@
         "enableRoleAssignments": {
             "value": false
         },
+        "cognitiveServiceKind": {
+            "value": "None"
+        },
         "subnetId": {
             "value": "/subscriptions/2150d511-458f-43b9-8691-6819ba2e6c7b/resourceGroups/dlz01-dev-network/providers/Microsoft.Network/virtualNetworks/dlz01-dev-vnet/subnets/DataProduct001Subnet"
         },

--- a/infra/params.dev.json
+++ b/infra/params.dev.json
@@ -53,8 +53,11 @@
         "enableRoleAssignments": {
             "value": false
         },
-        "cognitiveServiceKind": {
-            "value": "None"
+        "cognitiveServiceKinds": {
+            "value": []
+        },
+        "enableSearch": {
+            "value": false
         },
         "subnetId": {
             "value": "/subscriptions/2150d511-458f-43b9-8691-6819ba2e6c7b/resourceGroups/dlz01-dev-network/providers/Microsoft.Network/virtualNetworks/dlz01-dev-vnet/subnets/DataProduct001Subnet"

--- a/infra/params.dev.json
+++ b/infra/params.dev.json
@@ -54,10 +54,13 @@
             "value": false
         },
         "cognitiveServiceKinds": {
-            "value": []
+            "value": [
+                "CustomVision.Training",
+                "CustomVision.Prediction"
+            ]
         },
         "enableSearch": {
-            "value": false
+            "value": true
         },
         "subnetId": {
             "value": "/subscriptions/2150d511-458f-43b9-8691-6819ba2e6c7b/resourceGroups/dlz01-dev-network/providers/Microsoft.Network/virtualNetworks/dlz01-dev-vnet/subnets/DataProduct001Subnet"

--- a/infra/params.prod.json
+++ b/infra/params.prod.json
@@ -53,6 +53,9 @@
         "enableRoleAssignments": {
             "value": false
         },
+        "cognitiveServiceKind": {
+            "value": "None"
+        },
         "subnetId": {
             "value": "/subscriptions/2150d511-458f-43b9-8691-6819ba2e6c7b/resourceGroups/dlz01-prod-network/providers/Microsoft.Network/virtualNetworks/dlz01-prod-vnet/subnets/DataProduct001Subnet"
         },

--- a/infra/params.prod.json
+++ b/infra/params.prod.json
@@ -54,10 +54,13 @@
             "value": false
         },
         "cognitiveServiceKinds": {
-            "value": []
+            "value": [
+                "CustomVision.Training",
+                "CustomVision.Prediction"
+            ]
         },
         "enableSearch": {
-            "value": false
+            "value": true
         },
         "subnetId": {
             "value": "/subscriptions/2150d511-458f-43b9-8691-6819ba2e6c7b/resourceGroups/dlz01-prod-network/providers/Microsoft.Network/virtualNetworks/dlz01-prod-vnet/subnets/DataProduct001Subnet"

--- a/infra/params.prod.json
+++ b/infra/params.prod.json
@@ -53,8 +53,11 @@
         "enableRoleAssignments": {
             "value": false
         },
-        "cognitiveServiceKind": {
-            "value": "None"
+        "cognitiveServiceKinds": {
+            "value": []
+        },
+        "enableSearch": {
+            "value": false
         },
         "subnetId": {
             "value": "/subscriptions/2150d511-458f-43b9-8691-6819ba2e6c7b/resourceGroups/dlz01-prod-network/providers/Microsoft.Network/virtualNetworks/dlz01-prod-vnet/subnets/DataProduct001Subnet"

--- a/infra/params.test.json
+++ b/infra/params.test.json
@@ -54,10 +54,13 @@
             "value": false
         },
         "cognitiveServiceKinds": {
-            "value": []
+            "value": [
+                "CustomVision.Training",
+                "CustomVision.Prediction"
+            ]
         },
         "enableSearch": {
-            "value": false
+            "value": true
         },
         "subnetId": {
             "value": "/subscriptions/2150d511-458f-43b9-8691-6819ba2e6c7b/resourceGroups/dlz01-test-network/providers/Microsoft.Network/virtualNetworks/dlz01-test-vnet/subnets/DataProduct001Subnet"

--- a/infra/params.test.json
+++ b/infra/params.test.json
@@ -53,8 +53,11 @@
         "enableRoleAssignments": {
             "value": false
         },
-        "cognitiveServiceKind": {
-            "value": "None"
+        "cognitiveServiceKinds": {
+            "value": []
+        },
+        "enableSearch": {
+            "value": false
         },
         "subnetId": {
             "value": "/subscriptions/2150d511-458f-43b9-8691-6819ba2e6c7b/resourceGroups/dlz01-test-network/providers/Microsoft.Network/virtualNetworks/dlz01-test-vnet/subnets/DataProduct001Subnet"

--- a/infra/params.test.json
+++ b/infra/params.test.json
@@ -53,6 +53,9 @@
         "enableRoleAssignments": {
             "value": false
         },
+        "cognitiveServiceKind": {
+            "value": "None"
+        },
         "subnetId": {
             "value": "/subscriptions/2150d511-458f-43b9-8691-6819ba2e6c7b/resourceGroups/dlz01-test-network/providers/Microsoft.Network/virtualNetworks/dlz01-test-vnet/subnets/DataProduct001Subnet"
         },


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes. 
-->

**This PR fixes**
* This PR will add the option for users to select a specific Cognitive Service Kind for the deployment. Before, we deployed a default kind. Now there is the option in the Portal and in Bicep to select the Kind for this deployment.
* Updated API version of app insights.
* Linting
* Here is a screenshot of the Portal experience:
![image](https://user-images.githubusercontent.com/34542414/133634983-1ffa8393-2609-4d80-b8a5-6e7da832f45f.png)
