### PR TITLE
Make SQL Pool Deployment Optional

### DIFF
--- a/docs/reference/portal.dataProduct.json
+++ b/docs/reference/portal.dataProduct.json
@@ -805,6 +805,18 @@
                                         "allowedValues": "[map(steps('generalSettings').dataProcessingServiceDeploymentSettings.synapseDefaultStorageAccountFileSystemApi.value, (item) => parse(concat('{\"label\":\"', item.name, '\",\"value\":\"', item.id, '\"}')))]",
                                         "required": true
                                     }
+                                },
+                                {
+                                    "name": "enableSqlPool",
+                                    "label": "Enable SQL Pool",
+                                    "type": "Microsoft.Common.CheckBox",
+                                    "visible": "[equals(steps('generalSettings').dataProcessingServiceDeploymentSettings.processingService, 'synapse')]",
+                                    "defaultValue": false,
+                                    "toolTip": "Enable the deployment of an Azure SQL Pool (DW100).",
+                                    "constraints": {
+                                        "required": false,
+                                        "validationMessage": "Enable the deployment of an Azure SQL Pool (DW100)."
+                                    }
                                 }
                             ]
                         },
@@ -1412,6 +1424,7 @@
                 "machineLearningComputeInstance001AdministratorPublicSshKey": "[if(empty(steps('generalSettings').machineLearningDeploymentSettings.machineLearningComputeInstance001AdministratorPublicSshKey), '', steps('generalSettings').machineLearningDeploymentSettings.machineLearningComputeInstance001AdministratorPublicSshKey)]",
                 "administratorPassword": "[if(empty(steps('generalSettings').dataProcessingServiceDeploymentSettings.administratorPassword.password), '', steps('generalSettings').dataProcessingServiceDeploymentSettings.administratorPassword.password)]",
                 "synapseDefaultStorageAccountFileSystemId": "[if(empty(steps('generalSettings').dataProcessingServiceDeploymentSettings.synapseDefaultStorageAccountFileSystemId), '', steps('generalSettings').dataProcessingServiceDeploymentSettings.synapseDefaultStorageAccountFileSystemId)]",
+                "enableSqlPool": "[steps('generalSettings').dataProcessingServiceDeploymentSettings.enableSqlPool]",
                 "purviewId": "[if(empty(steps('generalSettings').dataGovernanceSettings.purviewId.id), '', steps('generalSettings').dataGovernanceSettings.purviewId.id)]",
                 "purviewManagedStorageId": "[if(empty(steps('generalSettings').dataGovernanceSettings.purviewId.id), '', steps('generalSettings').dataGovernanceSettings.purviewApi.properties.managedResources.storageAccount)]",
                 "purviewManagedEventHubId": "[if(empty(steps('generalSettings').dataGovernanceSettings.purviewId.id), '', steps('generalSettings').dataGovernanceSettings.purviewApi.properties.managedResources.eventHubNamespace)]",

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -43,6 +43,8 @@ param machineLearningComputeInstance001AdministratorPublicSshKey string = ''
 param administratorPassword string = ''
 @description('Specifies the resource ID of the default storage account file system for Synapse. If you selected dataFactory as processingService, leave this value empty as is.')
 param synapseDefaultStorageAccountFileSystemId string = ''
+@description('Specifies whether an Azure SQL Pool should be deployed inside your Synapse workspace as part of the template. If you selected dataFactory as processingService, leave this value as is.')
+param enableSqlPool bool = false
 @description('Specifies the resource ID of the central purview instance to connect Purviw with Data Factory or Synapse. If you do not want to setup a connection to Purview, leave this value empty as is.')
 param purviewId string = ''
 @description('Specifies the resource ID of the managed storage of the central purview instance.')
@@ -165,6 +167,7 @@ module synapse001 'modules/services/synapse.bicep' = if (processingService == 's
     privateDnsZoneIdSynapseDev: privateDnsZoneIdSynapseDev
     privateDnsZoneIdSynapseSql: privateDnsZoneIdSynapseSql
     purviewId: purviewId
+    enableSqlPool: enableSqlPool
     synapseComputeSubnetId: ''
     synapseDefaultStorageAccountFileSystemId: synapseDefaultStorageAccountFileSystemId
   }

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.4.1008.15138",
-      "templateHash": "5105924520370151573"
+      "templateHash": "1184862367173489986"
     }
   },
   "parameters": {
@@ -100,6 +100,13 @@
       "defaultValue": "",
       "metadata": {
         "description": "Specifies the resource ID of the default storage account file system for Synapse. If you selected dataFactory as processingService, leave this value empty as is."
+      }
+    },
+    "enableSqlPool": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Specifies whether an Azure SQL Pool should be deployed inside your Synapse workspace as part of the template. If you selected dataFactory as processingService, leave this value as is."
       }
     },
     "purviewId": {
@@ -497,6 +504,9 @@
           "purviewId": {
             "value": "[parameters('purviewId')]"
           },
+          "enableSqlPool": {
+            "value": "[parameters('enableSqlPool')]"
+          },
           "synapseComputeSubnetId": {
             "value": ""
           },
@@ -511,7 +521,7 @@
             "_generator": {
               "name": "bicep",
               "version": "0.4.1008.15138",
-              "templateHash": "1110043565915018942"
+              "templateHash": "16199153532241297171"
             }
           },
           "parameters": {
@@ -560,6 +570,10 @@
             "purviewId": {
               "type": "string",
               "defaultValue": ""
+            },
+            "enableSqlPool": {
+              "type": "bool",
+              "defaultValue": false
             }
           },
           "functions": [],
@@ -604,6 +618,7 @@
               }
             },
             {
+              "condition": "[parameters('enableSqlPool')]",
               "type": "Microsoft.Synapse/workspaces/sqlPools",
               "apiVersion": "2021-03-01",
               "name": "[format('{0}/{1}', parameters('synapseName'), 'sqlPool001')]",

--- a/infra/modules/services/synapse.bicep
+++ b/infra/modules/services/synapse.bicep
@@ -19,6 +19,7 @@ param synapseComputeSubnetId string = ''
 param privateDnsZoneIdSynapseSql string = ''
 param privateDnsZoneIdSynapseDev string = ''
 param purviewId string = ''
+param enableSqlPool bool = false
 
 // Variables
 var synapseDefaultStorageAccountFileSystemName = length(split(synapseDefaultStorageAccountFileSystemId, '/')) >= 13 ? last(split(synapseDefaultStorageAccountFileSystemId, '/')) : 'incorrectSegmentLength'
@@ -59,7 +60,7 @@ resource synapse 'Microsoft.Synapse/workspaces@2021-03-01' = {
   }
 }
 
-resource synapseSqlPool001 'Microsoft.Synapse/workspaces/sqlPools@2021-03-01' = {
+resource synapseSqlPool001 'Microsoft.Synapse/workspaces/sqlPools@2021-03-01' = if(enableSqlPool) {
   parent: synapse
   name: 'sqlPool001'
   location: location

--- a/infra/params.dev.json
+++ b/infra/params.dev.json
@@ -38,6 +38,9 @@
         "synapseDefaultStorageAccountFileSystemId": {
             "value": "/subscriptions/2150d511-458f-43b9-8691-6819ba2e6c7b/resourceGroups/dlz01-dev-storage/providers/Microsoft.Storage/storageAccounts/dlz01devwork/blobServices/default/containers/dp001"
         },
+        "enableSqlPool": {
+            "value": true
+        },
         "purviewId": {
             "value": "/subscriptions/17588eb2-2943-461a-ab3f-00a3ceac3112/resourceGroups/dmz-dev-governance/providers/Microsoft.Purview/accounts/dmz-dev-purview001"
         },

--- a/infra/params.prod.json
+++ b/infra/params.prod.json
@@ -38,6 +38,9 @@
         "synapseDefaultStorageAccountFileSystemId": {
             "value": "/subscriptions/2150d511-458f-43b9-8691-6819ba2e6c7b/resourceGroups/dlz01-prd-storage/providers/Microsoft.Storage/storageAccounts/dlz01prdwork/blobServices/default/containers/dp001"
         },
+        "enableSqlPool": {
+            "value": true
+        },
         "purviewId": {
             "value": "/subscriptions/17588eb2-2943-461a-ab3f-00a3ceac3112/resourceGroups/dmz-prd-governance/providers/Microsoft.Purview/accounts/dmz-prd-purview001"
         },

--- a/infra/params.test.json
+++ b/infra/params.test.json
@@ -38,6 +38,9 @@
         "synapseDefaultStorageAccountFileSystemId": {
             "value": "/subscriptions/2150d511-458f-43b9-8691-6819ba2e6c7b/resourceGroups/dlz01-tst-storage/providers/Microsoft.Storage/storageAccounts/dlz01tstwork/blobServices/default/containers/dp001"
         },
+        "enableSqlPool": {
+            "value": true
+        },
         "purviewId": {
             "value": "/subscriptions/17588eb2-2943-461a-ab3f-00a3ceac3112/resourceGroups/dmz-tst-governance/providers/Microsoft.Purview/accounts/dmz-tst-purview001"
         },


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please: 
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes. 
-->

**This PR fixes**
This PR allows to optionally deploy a sql pool if Synapse is selected as the data processing service.